### PR TITLE
Make screenshot images not to squish

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -79,10 +79,6 @@ body{
 	width: 100%;
 	margin-bottom: 80px;
 
-	.screenshot {
-		height: 300px;
-	}
-
 	.info {
 		min-height: 300px;
 		background-color: #fff;


### PR DESCRIPTION
The screenshot images are squished in smaller screen sizes. This is a quick fix for that. Another solution would be to crop the images (but how?).
