### PR TITLE
Add project "iOS Good Practices"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,3 +40,7 @@ projects:
         github_repo_name: android-best-practices
         description: android-best-practices.md
         screenshot: http://i.imgur.com/cJ5uRqs.png
+      - title: iOS Good Practices
+        github_repo_name: ios-good-practices
+        description: ios-good-practices.md
+        screenshot: http://i.imgur.com/VStsc7m.png

--- a/_includes/ios-good-practices.md
+++ b/_includes/ios-good-practices.md
@@ -1,0 +1,1 @@
+A collection of good and battle-proven practices for creating iOS apps, curated by Futurice developers. While you can always choose to do things differently, this document provides valuable suggestions and shortcuts. Learn from our experiences with project setups, architectures, the build pipeline, diagnostics, and much more!


### PR DESCRIPTION
I've included the iOS Good Practices document in our project overview. Are we good to merge?
